### PR TITLE
force unix path separator in generated astro files

### DIFF
--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -1,4 +1,4 @@
-import { resolve, sep } from "node:path"
+import { resolve, posix } from "node:path"
 import { isDirectory } from "$lib/filesystem"
 import { merge } from "$lib/object-literal"
 import type { Command } from "$lib/argv"
@@ -51,7 +51,7 @@ export async function executeSync(
 			generatePageProxy(
 				pagesMetadata.directory,
 				page.path,
-				translatePath(page.path, langCode, astroI18nConfig, sep),
+				translatePath(page.path, langCode, astroI18nConfig, posix.sep),
 				page.hasGetStaticPaths,
 			)
 		}

--- a/src/core/fs/generators/page.proxy.ts
+++ b/src/core/fs/generators/page.proxy.ts
@@ -1,4 +1,4 @@
-import { join, sep } from "node:path"
+import { join, posix, sep } from "node:path"
 import {
 	removeLeadingSep,
 	removeTrailingSep,
@@ -15,7 +15,10 @@ export function generatePageProxy(
 		0,
 		removeLeadingSep(removeTrailingSep(proxyPath)).split(sep).length - 1,
 	)
-	const importPath = `"${join("../".repeat(depth), pagePath)}"\n\n`
+	const importPath = `"${posix.join(
+		"../".repeat(depth),
+		pagePath.replaceAll("\\", "/"),
+	)}"\n\n`
 
 	let pageProxy = `---\nimport Page from ${importPath}`
 	if (importGetStaticPaths) {


### PR DESCRIPTION
This makes it possible to build https://github.com/tauri-apps/tauri-docs/tree/feat/docs-2.0 on Windows, that said, i may have missed something that is not used by our docs (which is why i mentioned them in the first place)

(sorry for the draft conversion, thought i missed something but my test dir just wasn't clean)