### PR TITLE
prerender is not always true

### DIFF
--- a/src/cli/commands/sync.pages.ts
+++ b/src/cli/commands/sync.pages.ts
@@ -45,7 +45,7 @@ export async function executeSyncPages(
 				page.path,
 				translatePath(page.path, langCode, astroI18nConfig, sep),
 				page.hasGetStaticPaths,
-				page.hasPrerender,
+				page.originPrerender,
 			)
 		}
 	}

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -53,7 +53,7 @@ export async function executeSync(
 				page.path,
 				translatePath(page.path, langCode, astroI18nConfig, posix.sep),
 				page.hasGetStaticPaths,
-				page.hasPrerender,
+				page.originPrerender,
 			)
 		}
 	}

--- a/src/core/fs/generators/page.proxy.ts
+++ b/src/core/fs/generators/page.proxy.ts
@@ -11,7 +11,7 @@ export function generatePageProxy(
 	pagePath: string,
 	proxyPath: string,
 	importGetStaticPaths: boolean,
-	exportPrerender: boolean,
+	originPrerender: string | undefined,
 ) {
 	const depth = Math.max(
 		0,
@@ -26,8 +26,8 @@ export function generatePageProxy(
 	if (importGetStaticPaths) {
 		pageProxy += getStaticPaths(importPath)
 	}
-	if (exportPrerender) {
-		pageProxy += "export const prerender = true\n\n"
+	if (originPrerender) {
+		pageProxy += `${originPrerender}\n\n`
 	}
 
 	pageProxy += "const { props } = Astro\n---\n\n<Page {...props} />"

--- a/src/core/fs/index.ts
+++ b/src/core/fs/index.ts
@@ -84,7 +84,7 @@ export function getPagesMetadata(
 						route,
 						path: "",
 						hasGetStaticPaths: false,
-						hasPrerender: false,
+						originPrerender: undefined,
 					}
 				}
 
@@ -93,7 +93,8 @@ export function getPagesMetadata(
 					routePageInfo[route].path = relativePath
 					routePageInfo[route].hasGetStaticPaths =
 						hasGetStaticPaths(fullPath)
-					routePageInfo[route].hasPrerender = hasPrerender(fullPath)
+					routePageInfo[route].originPrerender =
+						prerenderLine(fullPath)
 					routePageInfo[route].name = name
 				} else {
 					// translation directory
@@ -250,18 +251,23 @@ function hasGetStaticPaths(path: string) {
 	}
 }
 
-function hasPrerender(path: string) {
+function prerenderLine(path: string) {
 	try {
-		const file = readFileSync(path, "utf8")
-		return [
-			"export const prerender",
-			"export let prerender",
-			"export var prerender",
-			"export { prerender }",
-			"export {prerender}",
-		].some((searchString) => file.includes(searchString))
+		const list = readFileSync(path, "utf8")
+			.split("\n")
+			.filter((line) => {
+				return [
+					"export const prerender",
+					"export let prerender",
+					"export var prerender",
+					"export { prerender }",
+					"export {prerender}",
+				].some((searchString) => line.includes(searchString))
+			})
+			.map((line) => line.trim())
+		return list[0]
 	} catch (error) {
-		return false
+		return
 	}
 }
 

--- a/src/types/app/index.ts
+++ b/src/types/app/index.ts
@@ -6,7 +6,10 @@ export type PageInfo = {
 	route: string
 	path: string
 	hasGetStaticPaths: boolean
-	hasPrerender: boolean
+	/**
+	 * The origin prerender definition line
+	 */
+	originPrerender: string | undefined
 }
 
 export type PagesMetadata = ReturnType<typeof getPagesMetadata>


### PR DESCRIPTION
In astro [SSR hybrid](https://docs.astro.build/en/guides/server-side-rendering/#opting-out-of-pre-rendering), there might be some server-rendered pages that should be add `export const prerender = false`。So if  `prerender` value is based on the user's definition, that will be perfect.