### PR TITLE
Fix language detection in routes

### DIFF
--- a/src/core/routing/lang.code.ts
+++ b/src/core/routing/lang.code.ts
@@ -29,5 +29,5 @@ export function removeRouteLangCode(
 }
 
 export function extractRouteLangCode(route: string, langCodes: string[]) {
-	return route.match(new RegExp(`/?(${langCodes.join("|")})(?:/.*)?$`))?.[1]
+	return route.match(new RegExp(`^/(${langCodes.join("|")})(?:/|$)`))?.[1]
 }


### PR DESCRIPTION
I have a page "/all-sites" and the "es" at the end made the page to be detected as spanish, even if it doesn't have the "/es" at the beginning of the route.
I modified the regex from "extractRouteLangCode".