### PR TITLE
Add ability to set custom source directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ export default defineAstroI18nConfig({
 	trailingSlash: "never",
 	translations: {},
 	routeTranslations: {},
+	srcDir: "src",
 })
 ```
 
@@ -204,6 +205,12 @@ export default defineAstroI18nConfig({
 	},
 })
 ```
+
+#### `srcDir`
+
+Set the directory that Astro will read your site from. The value can be either an absolute file system path or a path relative to the project root.
+
+It's `src` by default.
 
 ### That's it
 

--- a/src/cli/commands/extract.keys.ts
+++ b/src/cli/commands/extract.keys.ts
@@ -2,6 +2,7 @@ import { resolve } from "node:path"
 import { isDirectory } from "$lib/filesystem"
 import { astroRootNotFound, noAstroRoot } from "$src/cli/errors"
 import { getPagesDirectoryRootRelativePath } from "$src/core/fs"
+import { loadAstroI18nConfig } from "$src/core/fs/config"
 import type { Command } from "$lib/argv"
 import { generateExtractedKeys } from "$src/core/fs/generators/extracted.keys"
 import { ASTRO_I18N_DIRECTORY } from "$src/constants"
@@ -11,10 +12,21 @@ export const extractKeys: Command = {
 	options: [],
 }
 
-export async function executeExtractKeys(args: string[]) {
+export async function executeExtractKeys(
+	args: string[],
+	options: {
+		config?: string[]
+	},
+) {
 	const root = args.at(0) ?? process.cwd()
 	if (!root) throw noAstroRoot()
-	const pages = resolve(root, getPagesDirectoryRootRelativePath())
+	const config = options.config?.at(0) && resolve(root, options.config[0])
+	const astroI18nConfig = await loadAstroI18nConfig(root, config)
+	const pages = resolve(
+		root,
+		getPagesDirectoryRootRelativePath(astroI18nConfig),
+	)
+
 	if (!isDirectory(pages)) throw astroRootNotFound(pages)
 
 	generateExtractedKeys(`${root}/src`, `${root}/${ASTRO_I18N_DIRECTORY}`)

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -9,6 +9,7 @@ import {
 import { merge } from "$lib/object-literal"
 import { astroRootNotFound, noAstroRoot } from "$src/cli/errors"
 import { getPagesDirectoryRootRelativePath } from "$src/core/fs"
+import { loadAstroI18nConfig } from "$src/core/fs/config"
 import { generateDefaultAstroI18nConfig } from "$src/core/fs/generators/astro.i18n.config"
 import { generateEnvDeclaration } from "$src/core/fs/generators/env.declaration"
 import { generateAstroConfig } from "$src/core/fs/generators/astro.config"
@@ -41,12 +42,18 @@ export async function executeInstall(
 ) {
 	const root = args.at(0) ?? process.cwd()
 	if (!root) throw noAstroRoot()
-	const pages = resolve(root, getPagesDirectoryRootRelativePath())
 	const config = options.config?.at(0) && resolve(root, options.config[0])
+	const astroI18nConfig = await loadAstroI18nConfig(root, config)
+
+	const pages = resolve(
+		root,
+		getPagesDirectoryRootRelativePath(astroI18nConfig),
+	)
+
 	if (!isDirectory(pages)) throw astroRootNotFound(pages)
 
 	generateDefaultAstroI18nConfig(root, config)
-	generateEnvDeclaration(root)
+	generateEnvDeclaration(root, astroI18nConfig)
 	generateAstroConfig(root)
 	addAstroI18nCommands(root)
 }

--- a/src/cli/commands/sync.pages.ts
+++ b/src/cli/commands/sync.pages.ts
@@ -29,11 +29,14 @@ export async function executeSyncPages(
 ) {
 	const root = args.at(0) ?? process.cwd()
 	if (!root) throw noAstroRoot()
-	const pages = resolve(root, getPagesDirectoryRootRelativePath())
 	const config = options.config?.at(0) && resolve(root, options.config[0])
-	if (!isDirectory(pages)) throw astroRootNotFound(pages)
-
 	const astroI18nConfig = await loadAstroI18nConfig(root, config)
+	const pages = resolve(
+		root,
+		getPagesDirectoryRootRelativePath(astroI18nConfig),
+	)
+
+	if (!isDirectory(pages)) throw astroRootNotFound(pages)
 
 	const pagesMetadata = getPagesMetadata(root, astroI18nConfig)
 	merge(astroI18nConfig.routeTranslations, pagesMetadata.routeTranslations)

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -31,11 +31,15 @@ export async function executeSync(
 ) {
 	const root = args.at(0) ?? process.cwd()
 	if (!root) throw noAstroRoot()
-	const pages = resolve(root, getPagesDirectoryRootRelativePath())
 	const config = options.config?.at(0) && resolve(root, options.config[0])
-	if (!isDirectory(pages)) throw astroRootNotFound(pages)
-
 	const astroI18nConfig = await loadAstroI18nConfig(root, config)
+
+	const pages = resolve(
+		root,
+		getPagesDirectoryRootRelativePath(astroI18nConfig),
+	)
+
+	if (!isDirectory(pages)) throw astroRootNotFound(pages)
 
 	const pagesMetadata = getPagesMetadata(root, astroI18nConfig)
 	merge(astroI18nConfig.translations, pagesMetadata.translations)

--- a/src/cli/commands/sync.types.ts
+++ b/src/cli/commands/sync.types.ts
@@ -2,6 +2,7 @@ import { resolve } from "node:path"
 import { isDirectory } from "$lib/filesystem"
 import { astroRootNotFound, noAstroRoot } from "$src/cli/errors"
 import { getPagesDirectoryRootRelativePath } from "$src/core/fs"
+import { loadAstroI18nConfig } from "$src/core/fs/config"
 import { generateAmbientType } from "$src/core/fs/generators/ambient.type"
 import type { Command } from "$lib/argv"
 
@@ -22,9 +23,16 @@ export async function executeSyncTypes(
 	},
 ) {
 	const root = args.at(0) ?? process.cwd()
+
 	if (!root) throw noAstroRoot()
-	const pages = resolve(root, getPagesDirectoryRootRelativePath())
+
 	const config = options.config?.at(0) && resolve(root, options.config[0])
+	const astroI18nConfig = await loadAstroI18nConfig(root, config)
+	const pages = resolve(
+		root,
+		getPagesDirectoryRootRelativePath(astroI18nConfig),
+	)
+
 	if (!isDirectory(pages)) throw astroRootNotFound(pages)
 
 	generateAmbientType(root, undefined, config)

--- a/src/core/fs/config/index.ts
+++ b/src/core/fs/config/index.ts
@@ -45,6 +45,7 @@ const defaultConfig: AstroI18nConfig = {
 	trailingSlash: "never",
 	translations: {},
 	routeTranslations: {},
+	srcDir: "src",
 }
 
 export function getDefaultConfig() {

--- a/src/core/fs/generators/env.declaration.ts
+++ b/src/core/fs/generators/env.declaration.ts
@@ -5,6 +5,7 @@ import { isFile, writeNestedFile } from "$lib/filesystem"
 import { ASTRO_I18N_DIRECTORY, GENERATED_DTS } from "$src/constants"
 import { getEnvDtsRootRelativePath } from "$src/core/fs"
 import { generateDefaultAmbientType } from "$src/core/fs/generators/ambient.type"
+import type { AstroI18nConfig } from "$src/types/config"
 
 const referencedPath = `..${sep}${ASTRO_I18N_DIRECTORY}${sep}${GENERATED_DTS}`
 const referencePathPattern = new RegExp(
@@ -12,10 +13,14 @@ const referencePathPattern = new RegExp(
 )
 const pathReference = `/// <reference path="${referencedPath}" />\n`
 
-export function generateEnvDeclaration(root: string) {
+export function generateEnvDeclaration(
+	root: string,
+	astroI18nConfig: AstroI18nConfig,
+) {
 	generateDefaultAmbientType(root)
 
-	const envDtsPath = join(root, getEnvDtsRootRelativePath())
+	const envDtsPath = join(root, getEnvDtsRootRelativePath(astroI18nConfig))
+
 	if (!isFile(envDtsPath)) {
 		writeNestedFile(envDtsPath, pathReference)
 		return
@@ -23,6 +28,7 @@ export function generateEnvDeclaration(root: string) {
 
 	const fileData = readFileSync(envDtsPath, "utf8")
 	const newFileData = getReferencedPathContent(fileData)
+
 	if (fileData !== newFileData) writeNestedFile(envDtsPath, newFileData)
 }
 

--- a/src/core/fs/index.ts
+++ b/src/core/fs/index.ts
@@ -37,12 +37,12 @@ export function getGeneratedDtsRootRelativePath() {
 	return join(ASTRO_I18N_DIRECTORY, GENERATED_DTS)
 }
 
-export function getPagesDirectoryRootRelativePath() {
-	return join("src", "pages")
+export function getPagesDirectoryRootRelativePath({ srcDir }: AstroI18nConfig) {
+	return join(srcDir, "pages")
 }
 
-export function getEnvDtsRootRelativePath() {
-	return join("src", ASTRO_ENV_DTS)
+export function getEnvDtsRootRelativePath({ srcDir }: AstroI18nConfig) {
+	return join(srcDir, ASTRO_ENV_DTS)
 }
 
 /**
@@ -53,7 +53,10 @@ export function getPagesMetadata(
 	astroI18nConfig: AstroI18nConfig,
 ) {
 	const { defaultLangCode, supportedLangCodes } = astroI18nConfig
-	const pagesDirectory = joinExists(root, getPagesDirectoryRootRelativePath())
+	const pagesDirectory = joinExists(
+		root,
+		getPagesDirectoryRootRelativePath(astroI18nConfig),
+	)
 	const routePageInfo: Record<string, PageInfo> = {}
 	const translations = createBaseTranslationObject<TranslationMap>([
 		defaultLangCode,
@@ -122,7 +125,7 @@ export function getPagesMetadata(
 }
 
 /**
- * Buils a `LoadedTranslationMap` from a directory of translations.
+ * Builds a `LoadedTranslationMap` from a directory of translations.
  */
 function getI18nPageTranslations(
 	directoryPath: string,

--- a/src/types/config/index.ts
+++ b/src/types/config/index.ts
@@ -8,6 +8,7 @@ export type UninitializedAstroI18nConfig = {
 	trailingSlash: "always" | "never"
 	translations: UninitializedTranslationMap
 	routeTranslations: UninitializedRouteTranslationMap
+	srcDir: string
 }
 export type AstroI18nConfig = ReplaceProperties<
 	UninitializedAstroI18nConfig,


### PR DESCRIPTION
Currently I cannot use this plugin with custom value of `srcDir` option in Astro config:
https://docs.astro.build/en/reference/configuration-reference/#srcdir

At this moment I get the following error:

```
 error   Path: /Users/azat/Developer/project/src/pages doesn't exist.
ReferenceError: Path: /Users/azat/Developer/project/src/pages doesn't exist.
```

Hope this PR will fix this issue 🙏 