### PR TITLE
Add missing #format method to formatter intl_format_date

### DIFF
--- a/astro-i18n/src/core/translation/formatters/default.formatters.ts
+++ b/astro-i18n/src/core/translation/formatters/default.formatters.ts
@@ -129,5 +129,5 @@ export function intl_format_date(
 		)
 	}
 
-	return new Intl.DateTimeFormat(locale, options)
+	return new Intl.DateTimeFormat(locale, options).format(value)
 }


### PR DESCRIPTION
If I'm not wrong, the method `intl_format_date` is missing the `format` method